### PR TITLE
fix: prevent tempfiles in var/transient

### DIFF
--- a/Classes/Templates/AbstractTemplate.php
+++ b/Classes/Templates/AbstractTemplate.php
@@ -40,7 +40,7 @@ class AbstractTemplate
     {
         $this->image = $image;
         $this->storage = $image->getStorage();
-        $this->imagePath = $this->storage->getFileForLocalProcessing($image);
+        $this->imagePath = $this->storage->getFileForLocalProcessing($image, false);
         $this->logger = $logger;
         $this->extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)
             ->get('image_jack');


### PR DESCRIPTION
This change fixes the issue where the /var/transient/ folder gets filled with numerous temporary images (fal-tempfile-xxxxxxxx) by ensuring that getFileForLocalProcessing() is called with writeable=false, preventing unnecessary file creations.

see #15 